### PR TITLE
add possibility to not create a release, but make exports available for following steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Since this action creates releases and uploads the zip file assets, you will nee
     - `%APPDATA%/Roaming/Godot/templates` for Windows
 - `relative_project_path`
   - The relative path to the directory containing your `project.godot` file. If your `project.godot` is at the root of your repository then this value should be `./`. Do _not_ include `project.godot` as part of this path.
+- `create_release` default `true`
+  - Enable release creation. If `false`, exports will be available in folder `exports` in `relativeProjectPath`.
 
 ### Example Workflow Configuration
 Below is a sample workflow configuration file utilizing this action. This example workflow would be defined in `.github/workflows/main.yml`. For more information about defining workflows [check out the workflow docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make sure that you have defined at least 1 export preset by going to `Project ->
 This action requires that your job utilizes Github's `actions/checkout@v1` so that the source code is available for Godot to export the game. See the below [example workflow configuration](#example-workflow-configuration) for an example.
 
 ### Environment Variables
-Since this action creates releases and uploads the zip file assets, you will need to supply the `GITHUB_TOKEN` environment variable. For an example on how to do this, see the below [example workflow configuration](#example-workflow-configuration).
+Since this action creates releases and uploads the zip file assets, you will need to supply the `GITHUB_TOKEN` environment variable. For an example on how to do this, see the below [example workflow configuration](#example-workflow-configuration). This environment variable is not needed if you set `create_release` to `false`.
 
 
 ### Inputs

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   godot_template_version:
     description: The name of the folder which templates are stored in. Looks like '3.1.1.stable.mono'. Can be found at %APPDATA\Roaming\Godot\templates on Windows and ~/.local/share/godot/templates on Linux.
     required: true
+  create_release:
+    description: Should a release be created.
+    default: true
+    required: false
 
 runs:
   using: 'node12'

--- a/lib/godot.js
+++ b/lib/godot.js
@@ -133,14 +133,26 @@ function createRelease(version, exportResults) {
         });
         const promises = [];
         for (const exportResult of exportResults) {
-            promises.push(zipAndUpload(response.data.upload_url, exportResult));
+            promises.push(upload(response.data.upload_url, yield zip(exportResult)));
         }
         yield Promise.all(promises);
         return 0;
     });
 }
 exports.createRelease = createRelease;
-function zipAndUpload(uploadUrl, exportResult) {
+function moveExports(exportResults) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield io.mkdirP(main_1.relativeProjectExportsPath);
+        const promises = [];
+        for (const exportResult of exportResults) {
+            promises.push(move(yield zip(exportResult)));
+        }
+        yield Promise.all(promises);
+        return 0;
+    });
+}
+exports.moveExports = moveExports;
+function zip(exportResult) {
     return __awaiter(this, void 0, void 0, function* () {
         const distPath = path.join(main_1.actionWorkingPath, 'dist');
         yield io.mkdirP(distPath);
@@ -153,6 +165,11 @@ function zipAndUpload(uploadUrl, exportResult) {
         else if (!fs.existsSync(zipPath)) {
             yield exec_1.exec('7z', ['a', zipPath, `${exportResult.buildDirectory}/*`]);
         }
+        return zipPath;
+    });
+}
+function upload(uploadUrl, zipPath) {
+    return __awaiter(this, void 0, void 0, function* () {
         const content = fs.readFileSync(zipPath);
         yield main_1.githubClient.repos.uploadReleaseAsset({
             file: content,
@@ -160,6 +177,11 @@ function zipAndUpload(uploadUrl, exportResult) {
             name: path.basename(zipPath),
             url: uploadUrl,
         });
+    });
+}
+function move(zipPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield io.mv(zipPath, path.join(main_1.relativeProjectExportsPath, path.basename(zipPath)));
     });
 }
 function findExecutablePath(basePath) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,6 +31,8 @@ const godotTemplateVersion = core.getInput('godot_template_version');
 exports.godotTemplateVersion = godotTemplateVersion;
 const relativeProjectPath = core.getInput('relative_project_path');
 exports.relativeProjectPath = relativeProjectPath;
+const relativeProjectExportsPath = path.join(relativeProjectPath, 'exports');
+exports.relativeProjectExportsPath = relativeProjectExportsPath;
 const githubClient = new github.GitHub((_a = process.env.GITHUB_TOKEN, (_a !== null && _a !== void 0 ? _a : '')));
 exports.githubClient = githubClient;
 function main() {
@@ -42,9 +44,16 @@ function main() {
         yield core.group('Godot setup', setupDependencies);
         const exportResults = yield core.group('Exporting', godot_1.runExport);
         if (exportResults) {
-            yield core.group(`Create release v${newVersion.format()}`, () => __awaiter(this, void 0, void 0, function* () {
-                yield godot_1.createRelease(newVersion, exportResults);
-            }));
+            if (core.getInput('create_release') === 'true') {
+                yield core.group(`Create release v${newVersion.format()}`, () => __awaiter(this, void 0, void 0, function* () {
+                    yield godot_1.createRelease(newVersion, exportResults);
+                }));
+            }
+            else {
+                yield core.group(`Move exported files`, () => __awaiter(this, void 0, void 0, function* () {
+                    yield godot_1.moveExports(exportResults);
+                }));
+            }
         }
         return 0;
     });

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,6 +31,7 @@ const godotTemplateVersion = core.getInput('godot_template_version');
 exports.godotTemplateVersion = godotTemplateVersion;
 const relativeProjectPath = core.getInput('relative_project_path');
 exports.relativeProjectPath = relativeProjectPath;
+const shouldCreateRelease = core.getInput('create_release') === 'true';
 const relativeProjectExportsPath = path.join(relativeProjectPath, 'exports');
 exports.relativeProjectExportsPath = relativeProjectExportsPath;
 const githubClient = new github.GitHub((_a = process.env.GITHUB_TOKEN, (_a !== null && _a !== void 0 ? _a : '')));
@@ -44,7 +45,7 @@ function main() {
         yield core.group('Godot setup', setupDependencies);
         const exportResults = yield core.group('Exporting', godot_1.runExport);
         if (exportResults) {
-            if (core.getInput('create_release') === 'true') {
+            if (shouldCreateRelease) {
                 yield core.group(`Create release v${newVersion.format()}`, () => __awaiter(this, void 0, void 0, function* () {
                     yield godot_1.createRelease(newVersion, exportResults);
                 }));
@@ -60,8 +61,8 @@ function main() {
 }
 function configCheck() {
     return __awaiter(this, void 0, void 0, function* () {
-        if (!process.env.GITHUB_TOKEN) {
-            throw new Error('You must supply the GITHUB_TOKEN environment variable.');
+        if (shouldCreateRelease && !process.env.GITHUB_TOKEN) {
+            throw new Error('You must supply the GITHUB_TOKEN environment variable to create a release.');
         }
         if (!godot_1.hasExportPresets()) {
             throw new Error('No "export_presets.cfg" found. Please be sure you have defined at least 1 export from the Godot editor.');


### PR DESCRIPTION
hello and thank you for this action!

I modified it so that it can export a game and let other steps decide what to do with the results.
My use case is to have nightly builds uploaded to s3, and also milestone releases on GitHub with the game available there also