### PR TITLE
Fix release determination issue

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -39,15 +39,18 @@ exports.githubClient = githubClient;
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         yield configCheck();
-        const newVersion = yield getAndCheckNewVersion();
-        core.info(`Using release version v${newVersion.format()}`);
+        let newReleaseVersion;
+        if (shouldCreateRelease) {
+            newReleaseVersion = yield getAndCheckNewVersion();
+            core.info(`Using release version v${newReleaseVersion.format()}`);
+        }
         yield setupWorkingPath();
         yield core.group('Godot setup', setupDependencies);
         const exportResults = yield core.group('Exporting', godot_1.runExport);
         if (exportResults) {
             if (shouldCreateRelease) {
-                yield core.group(`Create release v${newVersion.format()}`, () => __awaiter(this, void 0, void 0, function* () {
-                    yield godot_1.createRelease(newVersion, exportResults);
+                yield core.group(`Create release v${newReleaseVersion.format()}`, () => __awaiter(this, void 0, void 0, function* () {
+                    yield godot_1.createRelease(newReleaseVersion, exportResults);
                 }));
             }
             else {


### PR DESCRIPTION
This PR fixes a potential issue that could occur when `create_release` was set to false. Now the action will skip the release check if `create_release` is `false`.