### PR TITLE
[BREAKING CHANGE] Continue on #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ Since this action creates releases and uploads the zip file assets, you will nee
   - If release notes should be automatically generated based on commit history. The generated notes will be added as the body of the release.
   - **Note**: This input is only used when `create_release` is `true`.
   - **Note**: When using the GitHub checkout action, ensure you are fetching the entire project history by including `fetch-depth: 0`. See the example workflow configuration for more context.
-- `use_preset_export_path` default `false`
-  - If set to true, exports will be moved to directory defined in `export_presets.cfg` relative to the root of the Git repository. Prioritized over `relative_export_path`.
-- `relative_export_path` default `''`
-  - If provided, exports will be moved to this directory relative to the root of the Git repository.
+- `use_preset_export_path` default `true`
+  - If exports will be moved to the directory defined in `export_presets.cfg` relative to the root of the Git repository.
 - `update_windows_icons` default `false`
   - If Windows executable icons should be updated with the preset's `.ico` file.
   - **Note**: This process installs Wine and will need a small amount of additional run time. In my tests, this setting increased run time by approximately 30 seconds.

--- a/action.yml
+++ b/action.yml
@@ -38,12 +38,8 @@ inputs:
     default: false
     required: false
   use_preset_export_path:
-    description: If set to true, exports will be moved to directory defined in "export_presets.cfg" relative to the root of the Git repository. Prioritized over "relative_export_path".
-    default: false
-    required: false
-  relative_export_path:
-    description: If provided, exports will be moved to this directory relative to the root of the Git repository.
-    default: ''
+    description: If exports will be moved to the directory defined in "export_presets.cfg" relative to the root of the Git repository.
+    default: true
     required: false
   update_windows_icons:
     description: If Windows executable icons should be updated with the preset's .ico file.

--- a/dist/index.js
+++ b/dist/index.js
@@ -11917,7 +11917,6 @@ const BASE_VERSION = Object(core.getInput)('base_version');
 const GENERATE_RELEASE_NOTES = Object(core.getInput)('generate_release_notes') === 'true';
 const GODOT_DOWNLOAD_URL = Object(core.getInput)('godot_executable_download_url');
 const GODOT_TEMPLATES_DOWNLOAD_URL = Object(core.getInput)('godot_export_templates_download_url');
-const RELATIVE_EXPORT_PATH = Object(core.getInput)('relative_export_path');
 const RELATIVE_PROJECT_PATH = Object(core.getInput)('relative_project_path');
 const SHOULD_CREATE_RELEASE = Object(core.getInput)('create_release') === 'true';
 const UPDATE_WINDOWS_ICONS = Object(core.getInput)('update_windows_icons') === 'true';
@@ -12251,7 +12250,7 @@ function moveBuildsToExportDirectory(buildResults, moveArchived) {
         Object(core.startGroup)(`Moving exports`);
         const promises = [];
         for (const buildResult of buildResults) {
-            const fullExportPath = external_path_default().resolve(USE_PRESET_EXPORT_PATH ? external_path_default().dirname(buildResult.preset.export_path) : RELATIVE_EXPORT_PATH);
+            const fullExportPath = external_path_default().resolve(external_path_default().dirname(buildResult.preset.export_path));
             yield Object(io.mkdirP)(fullExportPath);
             let promise;
             if (moveArchived) {
@@ -12456,7 +12455,7 @@ function main() {
         if (ARCHIVE_EXPORT_OUTPUT) {
             yield zipBuildResults(buildResults);
         }
-        if (RELATIVE_EXPORT_PATH || USE_PRESET_EXPORT_PATH) {
+        if (USE_PRESET_EXPORT_PATH) {
             yield moveBuildsToExportDirectory(buildResults, ARCHIVE_EXPORT_OUTPUT);
         }
         if (SHOULD_CREATE_RELEASE) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,6 @@ const BASE_VERSION = core.getInput('base_version');
 const GENERATE_RELEASE_NOTES = core.getInput('generate_release_notes') === 'true';
 const GODOT_DOWNLOAD_URL = core.getInput('godot_executable_download_url');
 const GODOT_TEMPLATES_DOWNLOAD_URL = core.getInput('godot_export_templates_download_url');
-const RELATIVE_EXPORT_PATH = core.getInput('relative_export_path');
 const RELATIVE_PROJECT_PATH = core.getInput('relative_project_path');
 const SHOULD_CREATE_RELEASE = core.getInput('create_release') === 'true';
 const UPDATE_WINDOWS_ICONS = core.getInput('update_windows_icons') === 'true';
@@ -26,7 +25,6 @@ export {
   GODOT_DOWNLOAD_URL,
   GODOT_TEMPLATES_DOWNLOAD_URL,
   GODOT_WORKING_PATH,
-  RELATIVE_EXPORT_PATH,
   RELATIVE_PROJECT_PATH,
   SHOULD_CREATE_RELEASE,
   UPDATE_WINDOWS_ICONS,

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import * as io from '@actions/io';
 import { exec } from '@actions/exec';
 import * as fs from 'fs';
-import { GODOT_WORKING_PATH, RELATIVE_EXPORT_PATH, USE_PRESET_EXPORT_PATH } from './constants';
+import { GODOT_WORKING_PATH, USE_PRESET_EXPORT_PATH } from './constants';
 import * as core from '@actions/core';
 
 async function zipBuildResults(buildResults: BuildResult[]): Promise<void> {
@@ -38,9 +38,7 @@ async function moveBuildsToExportDirectory(buildResults: BuildResult[], moveArch
   core.startGroup(`Moving exports`);
   const promises: Promise<void>[] = [];
   for (const buildResult of buildResults) {
-    const fullExportPath = path.resolve(
-      USE_PRESET_EXPORT_PATH ? path.dirname(buildResult.preset.export_path) : RELATIVE_EXPORT_PATH,
-    );
+    const fullExportPath = path.resolve(path.dirname(buildResult.preset.export_path));
 
     await io.mkdirP(fullExportPath);
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import * as io from '@actions/io';
 import { exec } from '@actions/exec';
 import * as fs from 'fs';
-import { GODOT_WORKING_PATH, USE_PRESET_EXPORT_PATH } from './constants';
+import { GODOT_WORKING_PATH } from './constants';
 import * as core from '@actions/core';
 
 async function zipBuildResults(buildResults: BuildResult[]): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,7 @@
 import * as core from '@actions/core';
 import { exportBuilds } from './godot';
 import { createRelease } from './release';
-import {
-  SHOULD_CREATE_RELEASE,
-  ARCHIVE_EXPORT_OUTPUT,
-  USE_PRESET_EXPORT_PATH,
-} from './constants';
+import { SHOULD_CREATE_RELEASE, ARCHIVE_EXPORT_OUTPUT, USE_PRESET_EXPORT_PATH } from './constants';
 import { zipBuildResults, moveBuildsToExportDirectory } from './file';
 
 async function main(): Promise<number> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { createRelease } from './release';
 import {
   SHOULD_CREATE_RELEASE,
   ARCHIVE_EXPORT_OUTPUT,
-  RELATIVE_EXPORT_PATH,
   USE_PRESET_EXPORT_PATH,
 } from './constants';
 import { zipBuildResults, moveBuildsToExportDirectory } from './file';
@@ -20,7 +19,7 @@ async function main(): Promise<number> {
     await zipBuildResults(buildResults);
   }
 
-  if (RELATIVE_EXPORT_PATH || USE_PRESET_EXPORT_PATH) {
+  if (USE_PRESET_EXPORT_PATH) {
     await moveBuildsToExportDirectory(buildResults, ARCHIVE_EXPORT_OUTPUT);
   }
 


### PR DESCRIPTION
This removes `relative_export_path` over `use_preset_export_path`, and sets it to true by default.
Done in preparation for whenever 3.0 is published.