### PR TITLE
fix custom godot build version numbers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12998,7 +12998,7 @@ async function getGodotVersion() {
     };
     await Object(exec.exec)('godot', ['--version'], options);
     version = version.trim();
-    version = version.replace('.official', '');
+    version = version.replace('.official', '').replace(/\.[a-z0-9]{9}$/g, '');
     if (!version) {
         throw new Error('Godot version could not be determined.');
     }

--- a/src/godot.ts
+++ b/src/godot.ts
@@ -132,7 +132,7 @@ async function getGodotVersion(): Promise<string> {
 
   await exec('godot', ['--version'], options);
   version = version.trim();
-  version = version.replaceAll(/\.(official|[a-z0-9]{9}$)/g, '');
+  version = version.replace('.official', '').replace(/\.[a-z0-9]{9}$/g, '');
 
   if (!version) {
     throw new Error('Godot version could not be determined.');

--- a/src/godot.ts
+++ b/src/godot.ts
@@ -132,7 +132,7 @@ async function getGodotVersion(): Promise<string> {
 
   await exec('godot', ['--version'], options);
   version = version.trim();
-  version = version.replace('.official', '');
+  version = version.replaceAll(/\.(official|[a-z0-9]{9}$)/g, '');
 
   if (!version) {
     throw new Error('Godot version could not be determined.');


### PR DESCRIPTION
Fixes #64 

As it turns out, custom godot builds add a 9 digit long hash to the end of the string returned by --version:
```
static String get_full_version_string() {
	String hash = String(VERSION_HASH);
	if (hash.length() != 0)
		hash = "." + hash.left(9);
	return String(VERSION_FULL_BUILD) + hash;
}
```

I've added a regex to the getGodotVersion function to remove every occurence of a `.official` and/or any leading 9 digit hash starting with a dot.