### PR TITLE
Added case where macOS build is exported to .app

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -27,8 +27,11 @@ async function zipBuildResult(buildResult: BuildResult): Promise<void> {
 
   const zipPath = path.join(GODOT_ARCHIVE_PATH, `${buildResult.sanitizedName}.zip`);
 
-  // mac exports a zip by default, so just move the file
-  if (buildResult.preset.platform.toLowerCase() === 'mac osx') {
+  const isMac = buildResult.preset.platform.toLowerCase() === 'mac osx'
+  const endsInDotApp = !!buildResult.preset.export_path.match('\.app$')
+
+  // in case mac doesn't export a zip, move the file
+  if (isMac && !endsInDotApp) {
     const baseName = path.basename(buildResult.preset.export_path);
     const macPath = path.join(buildResult.directory, baseName);
     await io.cp(macPath, zipPath);


### PR DESCRIPTION
The code assumed people only export to `.zip` or `.dmg` for macOS, but there is an additional case where you deploy straight to `.app`. This pull request adds that case. I trust you'll do some testing to verify this works correctly before merging.

Let me know what you think or if you have additional questions ✨ 