### PR TITLE
Fix #118

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -59614,13 +59614,13 @@ async function downloadFile(filePath, downloadUrl, cacheKey, restoreKey) {
 async function downloadTemplates() {
     const templatesPath = external_path_.join(GODOT_WORKING_PATH, GODOT_TEMPLATES_FILENAME);
     const cacheKey = `godot-templates-${GODOT_TEMPLATES_DOWNLOAD_URL}`;
-    const restoreKey = `godot-templates-`;
+    const restoreKey = `godot-templates-${GODOT_TEMPLATES_DOWNLOAD_URL}`;
     await downloadFile(templatesPath, GODOT_TEMPLATES_DOWNLOAD_URL, cacheKey, restoreKey);
 }
 async function downloadExecutable() {
     const executablePath = external_path_.join(GODOT_WORKING_PATH, GODOT_ZIP);
     const cacheKey = `godot-executable-${GODOT_DOWNLOAD_URL}`;
-    const restoreKey = `godot-executable-`;
+    const restoreKey = `godot-executable-${GODOT_DOWNLOAD_URL}`;
     await downloadFile(executablePath, GODOT_DOWNLOAD_URL, cacheKey, restoreKey);
 }
 function isGhes() {

--- a/src/godot.ts
+++ b/src/godot.ts
@@ -110,14 +110,14 @@ async function downloadFile(
 async function downloadTemplates(): Promise<void> {
   const templatesPath = path.join(GODOT_WORKING_PATH, GODOT_TEMPLATES_FILENAME);
   const cacheKey = `godot-templates-${GODOT_TEMPLATES_DOWNLOAD_URL}`;
-  const restoreKey = `godot-templates-`;
+  const restoreKey = `godot-templates-${GODOT_TEMPLATES_DOWNLOAD_URL}`;
   await downloadFile(templatesPath, GODOT_TEMPLATES_DOWNLOAD_URL, cacheKey, restoreKey);
 }
 
 async function downloadExecutable(): Promise<void> {
   const executablePath = path.join(GODOT_WORKING_PATH, GODOT_ZIP);
   const cacheKey = `godot-executable-${GODOT_DOWNLOAD_URL}`;
-  const restoreKey = `godot-executable-`;
+  const restoreKey = `godot-executable-${GODOT_DOWNLOAD_URL}`;
   await downloadFile(executablePath, GODOT_DOWNLOAD_URL, cacheKey, restoreKey);
 }
 


### PR DESCRIPTION
Fixes cache overriding any capacity to change the download urls for Godot.

I manually changed index.js to share the same contents as godot.ts because `yarn build` blew up the diff for no reason, if it would be preferred to run it anyway I can, but the diff is ridiculous for how minute this change is. 