### PR TITLE
Add support for custom builds of Godot

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -59688,8 +59688,11 @@ async function getGodotVersion() {
     versionLines = versionLines.filter(x => !!x.trim());
     version = versionLines.pop() || 'unknown';
     version = version.trim();
-    version = version.replace('.official', '').replace(/\.[a-z0-9]{9}$/g, '');
-    if (!version) {
+    const regex = /(\d+(\.\d+)+\.\w+(\.mono)?)/;
+    const match = version.match(regex);    
+    if (match) {
+        version = match[1];
+    } else {
         throw new Error('Godot version could not be determined.');
     }
     return version;

--- a/src/godot.ts
+++ b/src/godot.ts
@@ -199,10 +199,12 @@ async function getGodotVersion(): Promise<string> {
   versionLines = versionLines.filter(x => !!x.trim());
   version = versionLines.pop() || 'unknown';
   version = version.trim();
-  version = version.replace('.official', '').replace(/\.[a-z0-9]{9}$/g, '');
-
-  if (!version) {
-    throw new Error('Godot version could not be determined.');
+  const regex = /(\d+(\.\d+)+\.\w+(\.mono)?)/;
+  const match = version.match(regex);    
+  if (match) {
+      version = match[1];
+  } else {
+      throw new Error('Godot version could not be determined.');
   }
 
   return version;


### PR DESCRIPTION

The current implementation doesn't support unofficial versions of the Godot engine. This PR implements a stronger string matching algorithm using regex to extract the version string, enabling support for all types of builds.

Tested with the following strings:

```javascript
const rawVersion1 = "4.4.dev.mono.custom_build.422eacdc6\n";
const rawVersion2 = "4.4.dev.custom_build.422eacdc6\n";
const rawVersion3 = "4.3.stable.official.77dcf97d8\n";
const rawVersion4 = "4.3.stable.mono.official.77dcf97d8\n";
```

All produced the following output:

```
Processed Godot version (with .mono): 4.4.dev.mono
Processed Godot version (without .mono): 4.4.dev
Processed Godot version (without .mono): 4.3.stable
Processed Godot version (with .mono): 4.3.stable.mono
```
