### PR TITLE
Create project_version optional argument for embedded versions

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -23,12 +23,13 @@ jobs:
         id: export
         uses: firebelley/godot-export@v7.0.0
         with:
-          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/4.0/Godot_v4.0-stable_linux.x86_64.zip
-          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/4.0/Godot_v4.0-stable_export_templates.tpz
+          godot_executable_download_url: https://github.com/godotengine/godot-builds/releases/download/4.4-stable/Godot_v4.4-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://github.com/godotengine/godot-builds/releases/download/4.4-stable/Godot_v4.4-stable_export_templates.tpz
           relative_project_path: ./examples/project-godot-4 # build the standard project
           relative_export_path: ./my/build/destination # move export output to this directory relative to git root
           archive_output: true
           wine_path: ${{ steps.wine_install.outputs.WINE_PATH }}
+          project_version: ${{ github.ref_name }}
       - name: create release
         uses: ncipollo/release-action@v1.18.0
         with:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Define at least 1 export preset by going to `Project -> Export` in the Godot edi
 | `use_godot_3`                         | Build using Godot 3 executable. **NOTE**: `godot_executable_download_url` and `godot_export_templates_download_url` still need to be configured to download the correct version.                                                                                                     | `boolean` | `false` | No       |
 | `export_as_pack`                      | Export project files as a .pck file                                                                                                                                                                                                                                                  | `boolean` | `false` | No       |
 | `presets_to_export`                   | A comma-separated list of export presets to export. If not specified, all presets will be exported. EX: `Windows, Mac OSX, android`                                                                                                                                                  | `string`  | `''`    | No       |
-
+| `project_version`                     | The version of your project. Sets the project settings `Application/Version` in Godot. | `string`  | `''`    | No       |
 
 ### Action Outputs
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Define at least 1 export preset by going to `Project -> Export` in the Godot edi
 | `use_godot_3`                         | Build using Godot 3 executable. **NOTE**: `godot_executable_download_url` and `godot_export_templates_download_url` still need to be configured to download the correct version.                                                                                                     | `boolean` | `false` | No       |
 | `export_as_pack`                      | Export project files as a .pck file                                                                                                                                                                                                                                                  | `boolean` | `false` | No       |
 | `presets_to_export`                   | A comma-separated list of export presets to export. If not specified, all presets will be exported. EX: `Windows, Mac OSX, android`                                                                                                                                                  | `string`  | `''`    | No       |
-| `project_version`                     | The version of your project. Sets the project settings `Application/Version` in Godot. | `string`  | `''`    | No       |
+| `project_version`                     | The version of your project. Sets the project settings `Application/Config/Version` in Godot. Useful for embedding version info into the exported game. | `string`  | `''`    | No       |
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: A comma-separated list of export presets to export. If not specified, all presets will be exported.
     default: ''
     required: false
+  project_version:
+    description: The version of your project. Sets the project settings `Application/Version` in Godot.
+    default: ''
+    required: false
     
 
 outputs:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ const GODOT_VERBOSE = core.getBooleanInput('verbose');
 const ARCHIVE_ROOT_FOLDER = core.getBooleanInput('archive_root_folder');
 const USE_GODOT_3 = core.getBooleanInput('use_godot_3');
 const EXPORT_PACK_ONLY = core.getBooleanInput('export_as_pack');
+const PROJECT_VERSION = core.getInput('project_version');
 
 // Parse export targets
 const exportPresetsStr = core.getInput('presets_to_export').trim();
@@ -73,4 +74,5 @@ export {
   USE_GODOT_3,
   USE_PRESET_EXPORT_PATH,
   WINE_PATH,
+  PROJECT_VERSION,
 };

--- a/src/godot.ts
+++ b/src/godot.ts
@@ -24,6 +24,7 @@ import {
   GODOT_EXPORT_TEMPLATES_PATH,
   CACHE_ACTIVE,
   GODOT_PROJECT_PATH,
+  PROJECT_VERSION,
 } from './constants';
 
 const GODOT_EXECUTABLE = 'godot_executable';
@@ -50,6 +51,12 @@ async function exportBuilds(): Promise<BuildResult[]> {
   core.startGroup('🔍 Adding Editor Settings');
   await addEditorSettings();
   core.endGroup();
+
+  if (PROJECT_VERSION) {
+    core.startGroup('🔧 Adding Project Settings');
+    setProjectVersion();
+    core.endGroup();
+  }
 
   if (WINE_PATH) {
     configureWindowsExport();
@@ -403,6 +410,50 @@ async function addEditorSettings(): Promise<void> {
   const editorSettingsPath = path.join(GODOT_CONFIG_PATH, EDITOR_SETTINGS_FILENAME);
   await io.cp(editorSettingsDist, editorSettingsPath, { force: false });
   core.info(`Wrote editor settings to ${editorSettingsPath}`);
+}
+
+function setProjectVersion(): void {
+  // Always update or insert config/version under [application] section
+  const projectFilePath = GODOT_PROJECT_FILE_PATH;
+  const content = fs.readFileSync(projectFilePath, { encoding: 'utf8' });
+  const lines = content.split(/\r?\n/);
+  let inApplication = false;
+  let versionSet = false;
+  const output: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('[application]')) {
+      inApplication = true;
+      output.push(line);
+      continue;
+    }
+    if (inApplication && line.startsWith('[')) {
+      // Leaving [application] section, insert version if not set
+      if (!versionSet && PROJECT_VERSION) {
+        output.push(`config/version = "${PROJECT_VERSION}"`);
+        versionSet = true;
+      }
+      inApplication = false;
+    }
+    if (inApplication && line.trim().startsWith('config/version')) {
+      if (PROJECT_VERSION) {
+        output.push(`config/version = "${PROJECT_VERSION}"`);
+      }
+      versionSet = true;
+      continue;
+    }
+    output.push(line);
+  }
+  // If [application] is at the end and version not set
+  if (inApplication && !versionSet && PROJECT_VERSION) {
+    output.push(`config/version = "${PROJECT_VERSION}"`);
+  }
+  fs.writeFileSync(projectFilePath, output.join('\n'), { encoding: 'utf8' });
+  if (PROJECT_VERSION) {
+    core.info(`Set project version to ${PROJECT_VERSION}`);
+  } else {
+    core.warning(`No project version set.`);
+  }
 }
 
 function configureWindowsExport(): void {


### PR DESCRIPTION
Adds a `project_version` optional argument for the yml file to update the `Application/Config/Version` in the godot project settings.

I wanted to automatically embed the release name into the game as the project version.

For example, if you set ``project_version: ${{ github.ref_name }}`` in the release .yml, when you push a tag like `v1.0.3.alpha.2`, the project.godot `Application/Config/Version` will be updated to be `v1.0.3.alpha.2`, which can be used in game to display the version, and is also used in the Windows export config by default if not overridden.

Also updated the urls in the build-example.yml because they were broken.