### PR TITLE
feat: updated linux check to include arm binaries

### DIFF
--- a/src/godot.ts
+++ b/src/godot.ts
@@ -348,7 +348,8 @@ function findGodotExecutablePath(basePath: string): string | undefined {
   for (const subPath of paths) {
     const fullPath = path.join(basePath, subPath);
     const stats = fs.statSync(fullPath);
-    const isLinux = stats.isFile() && (path.extname(fullPath) === '.64' || path.extname(fullPath) === '.x86_64');
+    const isLinux = stats.isFile() && (path.extname(fullPath) === '.64' || path.extname(fullPath) === '.x86_64'
+                      || path.extname(fullPath) === '.arm32' ||path.extname(fullPath) === '.arm64');
     const isMac = process.platform === 'darwin' && stats.isDirectory() && path.extname(fullPath) === '.app';
     if (isLinux) {
       return fullPath;


### PR DESCRIPTION
Updating a basic check to allow the linux check to include arm binaries.

Useful for arm-based build servers.