### PR TITLE
Bump action to node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,5 +70,5 @@ outputs:
     description: The directory containing archived exports if "archive_output" is set.
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
From github note:
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.